### PR TITLE
Use `fps` configuration to store auth secrets/config

### DIFF
--- a/plugins/auth/fps_auth/config.py
+++ b/plugins/auth/fps_auth/config.py
@@ -1,0 +1,14 @@
+from pydantic import SecretStr
+
+from fps.config import PluginModel  # type: ignore
+from fps.hooks import register_config, register_plugin_name  # type: ignore
+
+
+class AuthConfig(PluginModel):
+    client_id: str = ""
+    client_secret: SecretStr = ""
+    redirect_uri: str = ""
+
+
+c = register_config(AuthConfig)
+n = register_plugin_name("authenticator")

--- a/plugins/auth/fps_auth/config.py
+++ b/plugins/auth/fps_auth/config.py
@@ -1,12 +1,11 @@
-from pydantic import SecretStr
-
 from fps.config import PluginModel  # type: ignore
 from fps.hooks import register_config, register_plugin_name  # type: ignore
+from pydantic import SecretStr
 
 
 class AuthConfig(PluginModel):
     client_id: str = ""
-    client_secret: SecretStr = ""
+    client_secret: SecretStr = SecretStr("")
     redirect_uri: str = ""
 
 

--- a/plugins/auth/fps_auth/routes.py
+++ b/plugins/auth/fps_auth/routes.py
@@ -4,7 +4,7 @@ import fps  # type: ignore
 import httpx  # type: ignore
 from fastapi import APIRouter
 from fastapi.responses import RedirectResponse
-from fps.config import Config
+from fps.config import Config  # type: ignore
 from httpx_oauth.clients.github import GitHubOAuth2  # type: ignore
 
 from .config import AuthConfig

--- a/plugins/auth/setup.py
+++ b/plugins/auth/setup.py
@@ -3,5 +3,8 @@ from setuptools import setup  # type: ignore
 setup(
     name="fps_auth",
     install_requires=["fps", "httpx-oauth"],
-    entry_points={"fps_router": ["fps-auth = fps_auth.routes"]},
+    entry_points={
+        "fps_router": ["fps-auth = fps_auth.routes"],
+        "fps_config": ["fps-auth = fps_auth.config"],
+    },
 )


### PR DESCRIPTION
Description
---

Use `fps` configuration to store auth static secrets/config
Add the corresponding `entry_point`

This allows you to configure the plugin:
- from a config file (`fps.toml`, `authenticator.toml` or any other file passed as a CLI argument using `--config=<file>.toml`)
  ```
  [authenticator]
  client_id = "foo"
  ```
- from the CLI by passing one of the following extra args
  - `--authenticator.client_id=foo`
  - `--authenticator.client_id="foo"`
  -  `--authenticator.client_id foo`
  -  `--authenticator.client_id "foo"`

Note: 
- the `authenticator` name comes from the additional `n = register_plugin_name("authenticator")`
- if you decide to change it, it will be automatically reflected in 
  - the config filenames `<plugin-name>.toml`
  - the section name `[<plugin-name>]`
  - the CLI parsing of extra args (which is generating a config file for you)
- if you remove the `plugin_name` hook, the name will be defaulted to `auth` (`fps-` and `fps_` are automatically striped for package name for default plugin name)